### PR TITLE
Improved hanging indent

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,20 +20,20 @@
 		"onLanguage:python",
 		"onLanguage:jupyter",
 		"onDebugResolve:python",
-		"onCommand:extension.newlineAndIndent"
+		"onCommand:pythonIndent.newlineAndIndent"
 	],
 	"main": "./out/extension.js",
 	"contributes": {
 		"keybindings": [
 			{
-				"command": "extension.newlineAndIndent",
+				"command": "pythonIndent.newlineAndIndent",
 				"key": "enter",
 				"when": "editorTextFocus && !editorHasSelection && editorLangId == python && !suggestWidgetVisible"
 			}
 		],
 		"commands": [
 			{
-				"command": "extension.newlineAndIndent",
+				"command": "pythonIndent.newlineAndIndent",
 				"title": "newline and auto indent"
 			}
 		]

--- a/package.json
+++ b/package.json
@@ -36,7 +36,18 @@
 				"command": "pythonIndent.newlineAndIndent",
 				"title": "newline and auto indent"
 			}
-		]
+        ],
+        "configuration": {
+            "type": "object",
+            "title": "Python Indent configuration",
+            "properties": {
+                "pythonIndent.useTabOnHangingIndent": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "After creating a hanging indent, press tab to leave the indented section and go to the ending bracket."
+                }
+            }
+        }
 	},
 	"scripts": {
 		"vscode:prepublish": "npm run compile",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,7 +6,7 @@ import { newlineAndIndent } from "./indent";
 // this method is called when your extension is activated
 // your extension is activated the very first time the command is executed
 export function activate(context: vscode.ExtensionContext) {
-	let disposable = vscode.commands.registerTextEditorCommand('extension.newlineAndIndent', newlineAndIndent);
+	let disposable = vscode.commands.registerTextEditorCommand('pythonIndent.newlineAndIndent', newlineAndIndent);
 	context.subscriptions.push(disposable);
 }
 

--- a/src/indent.ts
+++ b/src/indent.ts
@@ -11,6 +11,10 @@ export function newlineAndIndent(
     const position = textEditor.selection.active;
     const tabSize = <number>textEditor.options.tabSize!;
     const insertionPoint = new vscode.Position(position.line, position.character);
+    let snippetCursor = '$0';
+    if (vscode.workspace.getConfiguration('pythonIndent').useTabOnHangingIndent) {
+        snippetCursor = '$1';
+    }
     let shouldHang = false;
     let toInsert = '\n';
 
@@ -33,7 +37,7 @@ export function newlineAndIndent(
             // The VSCode snippet logic already does some indentation handling,
             // so don't use the toInsert, just ' ' * tabSize.
             // That behavior is not documented.
-            textEditor.insertSnippet(new vscode.SnippetString('\n' + ' '.repeat(tabSize) + '$0' + '\n'));
+            textEditor.insertSnippet(new vscode.SnippetString('\n' + ' '.repeat(tabSize) + snippetCursor + '\n'));
         } else {
             edit.insert(insertionPoint, toInsert);
         }

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -36,13 +36,13 @@ suite("nextIndentationLevel", function () {
             assert.equal(tabSize, indent.nextIndentationLevel(
                 ["def function(x):"],
                 tabSize,
-            ));
+            ).indent);
         });
         test("non-default indent size", function() {
             assert.equal(8, indent.nextIndentationLevel(
                 ["def function(x):"],
                 8,
-            ));
+            ).indent);
         });
         test("normal, within class", function() {
             assert.equal(tabSize * 2, indent.nextIndentationLevel(
@@ -51,7 +51,7 @@ suite("nextIndentationLevel", function () {
                     "    def function(x):",
                 ],
                 tabSize,
-            ));
+            ).indent);
         });
         test("broken up arguments", function() {
             assert.equal("def function(".length, indent.nextIndentationLevel(
@@ -59,7 +59,7 @@ suite("nextIndentationLevel", function () {
                     "def function(x,"
                 ],
                 tabSize,
-            ));
+            ).indent);
         });
         test("broken up arguments with type hints", function() {
             assert.equal("def function(".length, indent.nextIndentationLevel(
@@ -67,7 +67,7 @@ suite("nextIndentationLevel", function () {
                     "def function(x: int,"
                 ],
                 tabSize,
-            ));
+            ).indent);
         });
         test("broken up arguments final indent", function() {
             assert.equal(tabSize, indent.nextIndentationLevel(
@@ -76,7 +76,7 @@ suite("nextIndentationLevel", function () {
                     "             y):",
                 ],
                 tabSize,
-            ));
+            ).indent);
         });
         test("broken up arguments final indent with type hints", function() {
             assert.equal(tabSize, indent.nextIndentationLevel(
@@ -85,7 +85,7 @@ suite("nextIndentationLevel", function () {
                     "             y: float):",
                 ],
                 tabSize,
-            ));
+            ).indent);
         });
         test("broken up arguments with embedded list", function() {
             assert.equal("def function(x=[".length, indent.nextIndentationLevel(
@@ -93,7 +93,7 @@ suite("nextIndentationLevel", function () {
                     "def function(x=[0, 1,",
                 ],
                 tabSize,
-            ));
+            ).indent);
         });
     });
     suite("colon control flows", function () {
@@ -101,7 +101,7 @@ suite("nextIndentationLevel", function () {
             assert.equal(tabSize, indent.nextIndentationLevel(
                 ["if condition:"],
                 tabSize,
-            ));
+            ).indent);
         });
         test("if/else", function () {
             assert.equal(tabSize, indent.nextIndentationLevel(
@@ -111,7 +111,7 @@ suite("nextIndentationLevel", function () {
                     "else:"
                 ],
                 tabSize,
-            ));
+            ).indent);
         });
         test("for", function () {
             assert.equal(tabSize, indent.nextIndentationLevel(
@@ -119,7 +119,7 @@ suite("nextIndentationLevel", function () {
                     "for i in range(5):",
                 ],
                 tabSize,
-            ));
+            ).indent);
         });
         test("try", function () {
             assert.equal(tabSize, indent.nextIndentationLevel(
@@ -127,7 +127,7 @@ suite("nextIndentationLevel", function () {
                     "try:",
                 ],
                 tabSize,
-            ));
+            ).indent);
         });
         test("try/except", function () {
             assert.equal(tabSize, indent.nextIndentationLevel(
@@ -137,7 +137,7 @@ suite("nextIndentationLevel", function () {
                     "except ValueError:",
                 ],
                 tabSize,
-            ));
+            ).indent);
         });
     });
     suite("lists, dicts, and tuples", function () {
@@ -147,7 +147,7 @@ suite("nextIndentationLevel", function () {
                     "[0, 1, 2,",
                 ],
                 tabSize,
-            ));
+            ).indent);
         });
         test("list dedents at the end", function () {
             assert.equal(0, indent.nextIndentationLevel(
@@ -157,7 +157,7 @@ suite("nextIndentationLevel", function () {
                     " 6, 7, 8]",
                 ],
                 tabSize,
-            ));
+            ).indent);
         });
         test("list extended", function () {
             assert.equal(1, indent.nextIndentationLevel(
@@ -166,7 +166,7 @@ suite("nextIndentationLevel", function () {
                     " 3, 4, 5,"
                 ],
                 tabSize,
-            ));
+            ).indent);
         });
         test("nested lists", function () {
             assert.equal(2, indent.nextIndentationLevel(
@@ -174,33 +174,33 @@ suite("nextIndentationLevel", function () {
                     "[[0, 1, 2,",
                 ],
                 tabSize,
-            ));
+            ).indent);
             assert.equal(1, indent.nextIndentationLevel(
                 [
                     "[[0, 1, 2],",
                 ],
                 tabSize,
-            ));
+            ).indent);
             assert.equal("[0, 1, 2, [".length, indent.nextIndentationLevel(
                 [
                     "[0, 1, 2, [3, 4, 5,",
                 ],
                 tabSize,
-            ));
+            ).indent);
             assert.equal(2, indent.nextIndentationLevel(
                 [
                     "[0, 1, 2,",
                     " [3, 4, 5,",
                 ],
                 tabSize,
-            ));
+            ).indent);
             assert.equal(2, indent.nextIndentationLevel(
                 [
                     "[[[0, 1, 2,",
                     "   3, 4, 5],",
                 ],
                 tabSize,
-            ));
+            ).indent);
         });
         test("dict", function () {
             assert.equal(1, indent.nextIndentationLevel(
@@ -208,7 +208,7 @@ suite("nextIndentationLevel", function () {
                     "{'a': 0,",
                 ],
                 tabSize,
-            ));
+            ).indent);
         });
         test("dict extended", function () {
             assert.equal(1, indent.nextIndentationLevel(
@@ -217,7 +217,7 @@ suite("nextIndentationLevel", function () {
                     " 'b': 1,"
                 ],
                 tabSize,
-            ));
+            ).indent);
         });
         test("tuple", function () {
             assert.equal(1, indent.nextIndentationLevel(
@@ -225,7 +225,7 @@ suite("nextIndentationLevel", function () {
                     "(0, 1, 2,",
                 ],
                 tabSize,
-            ));
+            ).indent);
         });
         test("tuple extended", function () {
             assert.equal(1, indent.nextIndentationLevel(
@@ -234,7 +234,7 @@ suite("nextIndentationLevel", function () {
                     " 3, 4, 5,"
                 ],
                 tabSize,
-            ));
+            ).indent);
         });
         test("mixed", function () {
             assert.equal("{'a': [".length, indent.nextIndentationLevel(
@@ -242,13 +242,13 @@ suite("nextIndentationLevel", function () {
                     "{'a': [0, 1, 2,",
                 ],
                 tabSize,
-            ));
+            ).indent);
             assert.equal(1, indent.nextIndentationLevel(
                 [
                     "({'a': 0},",
                 ],
                 tabSize,
-            ));
+            ).indent);
         });
         test("starting indented", function () {
             assert.equal(5, indent.nextIndentationLevel(
@@ -256,28 +256,28 @@ suite("nextIndentationLevel", function () {
                     "    [0, 1, 2,",
                 ],
                 tabSize,
-            ));
+            ).indent);
             assert.equal(5, indent.nextIndentationLevel(
                 [
                     "    [0, 1, 2,",
                     "     3, 4, 5,"
                 ],
                 tabSize,
-            ));
+            ).indent);
             assert.equal(5, indent.nextIndentationLevel(
                 [
                     "    (0, 1, 2,",
                     "     3, 4, 5,"
                 ],
                 tabSize,
-            ));
+            ).indent);
             assert.equal(5, indent.nextIndentationLevel(
                 [
                     "    {0: 1,",
                     "     2: 3,"
                 ],
                 tabSize,
-            ));
+            ).indent);
         });
     });
     suite("hanging", function () {
@@ -287,7 +287,7 @@ suite("nextIndentationLevel", function () {
                     "("
                 ],
                 tabSize,
-            ));
+            ).indent);
         });
         test("starting indented", function () {
             assert.equal(8, indent.nextIndentationLevel(
@@ -295,7 +295,7 @@ suite("nextIndentationLevel", function () {
                     "    ("
                 ],
                 tabSize,
-            ));
+            ).indent);
         });
         test("non-default indent size", function () {
             assert.equal(8, indent.nextIndentationLevel(
@@ -303,7 +303,7 @@ suite("nextIndentationLevel", function () {
                     "("
                 ],
                 8,
-            ));
+            ).indent);
         });
     });
     suite("strings", function () {
@@ -313,7 +313,7 @@ suite("nextIndentationLevel", function () {
                     "['a', 'b',",
                 ],
                 tabSize,
-            ));
+            ).indent);
         });
         test("quoted bracket ender", function () {
             assert.equal(1, indent.nextIndentationLevel(
@@ -321,7 +321,7 @@ suite("nextIndentationLevel", function () {
                     "['a', 'b]',",
                 ],
                 tabSize,
-            ));
+            ).indent);
         });
         test("quoted bracket ender in raw", function () {
             assert.equal(1, indent.nextIndentationLevel(
@@ -329,7 +329,7 @@ suite("nextIndentationLevel", function () {
                     "['a', r'b]',",
                 ],
                 tabSize,
-            ));
+            ).indent);
         });
         test("just like REALLY messy", function () {
             const text = "\n\
@@ -347,7 +347,7 @@ x = ['here(\\'(', 'is', 'a',\n\
                 assert.equal(expectedIndents[i], indent.nextIndentationLevel(
                     lines.slice(undefined, i + 1),
                     tabSize,
-                ));
+                ).indent);
             }
         });
     });
@@ -358,7 +358,7 @@ x = ['here(\\'(', 'is', 'a',\n\
                     "[0, 1, 2, #",
                 ],
                 tabSize,
-            ));
+            ).indent);
         });
         test("commented bracket ender", function () {
             assert.equal(1, indent.nextIndentationLevel(
@@ -366,7 +366,7 @@ x = ['here(\\'(', 'is', 'a',\n\
                     "[0, 1, 2, #]",
                 ],
                 tabSize,
-            ));
+            ).indent);
         });
         test("commented bracket opener", function () {
             assert.equal(1, indent.nextIndentationLevel(
@@ -374,7 +374,7 @@ x = ['here(\\'(', 'is', 'a',\n\
                     "[0, 1, 2, #[",
                 ],
                 tabSize,
-            ));
+            ).indent);
         });
         test("additional text", function () {
             assert.equal(1, indent.nextIndentationLevel(
@@ -382,7 +382,27 @@ x = ['here(\\'(', 'is', 'a',\n\
                     "[0, 1, 2, #additional text and stuff",
                 ],
                 tabSize,
-            ));
+            ).indent);
+        });
+    });
+    suite("hanging", function () {
+        test("list", function () {
+            assert.equal(true, indent.nextIndentationLevel(
+                ["this_list = [",],
+                tabSize,
+            ).shouldHang);
+        });
+        test("function", function () {
+            assert.equal(true, indent.nextIndentationLevel(
+                ["def my_func(",],
+                tabSize,
+            ).shouldHang);
+        });
+        test("nested", function () {
+            assert.equal(true, indent.nextIndentationLevel(
+                ["class A:", "    def __init__("],
+                tabSize,
+            ).shouldHang);
         });
     });
     suite("dedent", function () {
@@ -393,7 +413,7 @@ x = ['here(\\'(', 'is', 'a',\n\
                     "    return x"
                 ],
                 tabSize,
-            ));
+            ).indent);
         });
         test("pass", function () {
             assert.equal(0, indent.nextIndentationLevel(
@@ -402,7 +422,7 @@ x = ['here(\\'(', 'is', 'a',\n\
                     "    pass"
                 ],
                 tabSize,
-            ));
+            ).indent);
         });
         test("break", function () {
             assert.equal(0, indent.nextIndentationLevel(
@@ -411,7 +431,7 @@ x = ['here(\\'(', 'is', 'a',\n\
                     "    break"
                 ],
                 tabSize,
-            ));
+            ).indent);
         });
         test("continue", function () {
             assert.equal(0, indent.nextIndentationLevel(
@@ -420,7 +440,7 @@ x = ['here(\\'(', 'is', 'a',\n\
                     "    continue"
                 ],
                 tabSize,
-            ));
+            ).indent);
         });
         test("raise", function () {
             assert.equal(0, indent.nextIndentationLevel(
@@ -429,7 +449,7 @@ x = ['here(\\'(', 'is', 'a',\n\
                     "    raise NotImplementedError('uh oh')"
                 ],
                 tabSize,
-            ));
+            ).indent);
         });
         test("return, starting indented", function () {
             assert.equal(tabSize, indent.nextIndentationLevel(
@@ -439,7 +459,7 @@ x = ['here(\\'(', 'is', 'a',\n\
                     "        return x"
                 ],
                 tabSize,
-            ));
+            ).indent);
         });
     });
 });

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -404,6 +404,12 @@ x = ['here(\\'(', 'is', 'a',\n\
                 tabSize,
             ).shouldHang);
         });
+        test("negative case", function () {
+            assert.equal(false, indent.nextIndentationLevel(
+                ["class A:", "    def __init__(self):"],
+                tabSize,
+            ).shouldHang);
+        });
     });
     suite("dedent", function () {
         test("return", function () {


### PR DESCRIPTION
Most indentation seems to be working quite well, but the good default behavior of VSCode's hanging indents has been lost.

* Recover the expected behavior during hanging indents.
* Maybe create option to use actual snippet or not?