### PR TITLE
add a unittest for return with bracket and fix

### DIFF
--- a/src/indent.ts
+++ b/src/indent.ts
@@ -64,7 +64,7 @@ export function nextIndentationLevel(
         return {indent: indentationLevel(lines[row]) + tabSize, shouldHang: true};
     }
 
-    if (dedent) {
+    if (dedent  && !openBracketStack.length) {
         return {indent: indentationLevel(lines[row]) - tabSize, shouldHang: false};
     }
 

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -467,5 +467,16 @@ x = ['here(\\'(', 'is', 'a',\n\
                 tabSize,
             ).indent);
         });
+
+        test("return, with bracket", function() {
+            assert.equal("        return self._connection_class()(".length , indent.nextIndentationLevel(
+                [
+                    "class A():",
+                    "    def handle_request(self, request, release_callback, callback):",
+                    "        return self._connection_class()(self, request, release_callback, callback"
+                ],
+                tabSize
+            ).indent);
+        })
     });
 });


### PR DESCRIPTION
current situation: 
```
def handle_request(self, request, relase_callback, callback):
        return self._connection_class()(self, request, relase_callback, callback,
| # indent here
```
which is not expected
after fix
```
def handle_request(self, request, relase_callback, callback):
        return self._connection_class()(self, request, relase_callback, callback,
                                                          |# indent here

```
although i dont understand code completely, but my fix seem works and dont break the unit test