### PR TITLE
Allow extension to work when text is selected

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,12 +29,12 @@
 			{
 				"command": "pythonIndent.newlineAndIndent",
 				"key": "enter",
-				"when": "editorTextFocus && !editorHasSelection && !editorHasMultipleSelections && editorLangId == python && !suggestWidgetVisible && !vim.active"
+				"when": "editorTextFocus && !editorHasMultipleSelections && editorLangId == python && !suggestWidgetVisible && !vim.active"
 			},
 			{
 				"command": "pythonIndent.newlineAndIndent",
 				"key": "enter",
-				"when": "editorTextFocus && !editorHasSelection && !editorHasMultipleSelections && editorLangId == python && !suggestWidgetVisible && vim.active == true && vim.mode =~ /(Insert|Replace|SurroundInputMode)/"
+				"when": "editorTextFocus && !editorHasMultipleSelections && editorLangId == python && !suggestWidgetVisible && vim.active == true && vim.mode =~ /(Insert|Replace|SurroundInputMode)/"
 			}
 		],
 		"commands": [

--- a/src/indent.ts
+++ b/src/indent.ts
@@ -19,6 +19,16 @@ export function newlineAndIndent(
     let hanging = Hanging.None;
     let toInsert = '\n';
 
+    // Get rid of any user selection since a selection is
+    // always deleted whenever ENTER is pressed.
+    let selected = textEditor.document.getText(textEditor.selection);
+    if (selected) {
+        edit.delete(textEditor.selection);
+        // Make sure we get rid of the selection range by moving the cursor.
+        // This is the equivalent of the user pushing the right arrow.
+        vscode.commands.executeCommand("cursorRight")
+    }
+
     try {
         if (textEditor.document.languageId === 'python') {
             const lines = textEditor.document.getText(


### PR DESCRIPTION
The issue with selected text is that we have to first delete the text and move the cursor so there is no registered selection. Once that is done, processing can continue without any modifications to the indentation logic.

Since there are no other changes to the code and the deletion of the selected text effectively makes this no different than the standard non-selected text case, this commit should be pretty stable.

Multi-line indentation still won't work unless a `for` loop is used to process each line separately, so that is still disabled in `package.json`. But, if it was implemented, the pre-emptive deletion in this commit leaves no special case for excluding `editorHasMultipleSelections` in `package.json`.