### PR TITLE
Fix detection of control statements

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,12 +29,12 @@
 			{
 				"command": "pythonIndent.newlineAndIndent",
 				"key": "enter",
-				"when": "editorTextFocus && !editorHasSelection && !editorHasMultipleSelections && editorLangId == python && !suggestWidgetVisible && !vim.active"
+				"when": "editorTextFocus && !editorHasMultipleSelections && editorLangId == python && !suggestWidgetVisible && !vim.active"
 			},
 			{
 				"command": "pythonIndent.newlineAndIndent",
 				"key": "enter",
-				"when": "editorTextFocus && !editorHasSelection && !editorHasMultipleSelections && editorLangId == python && !suggestWidgetVisible && vim.active == true && vim.mode =~ /(Insert|Replace|SurroundInputMode)/"
+				"when": "editorTextFocus && !editorHasMultipleSelections && editorLangId == python && !suggestWidgetVisible && vim.active == true && vim.mode =~ /(Insert|Replace|SurroundInputMode)/"
 			}
 		],
 		"commands": [

--- a/src/indent.ts
+++ b/src/indent.ts
@@ -185,8 +185,10 @@ function parseLines(lines: Array<string>) {
     let checkNextCharForString = false;
     // true if we should dedent the next row, false otherwise
     let dedentNext = false;
-    // if we see these words at the beginning of a line, dedent the next one
+    // If the entire line is one of these control statements, dedent the next one
     const dedentNextKeywords = ["return", "pass", "break", "continue", "raise"];
+    // If we see these words at the beginning of a line, dedent the next one
+    const dedentNextKeywords2 = ["return ", "raise "];
 
     // NOTE: this parsing will only be correct if the python code is well-formed
     // statements like "[0, (1, 2])" might break the parsing
@@ -195,7 +197,9 @@ function parseLines(lines: Array<string>) {
     const linesLength = lines.length;
     for (let row = 0; row < linesLength; row += 1) {
         const line = lines[row];
-        dedentNext = (stringDelimiter === null) && dedentNextKeywords.some((keyword) => line.trim().startsWith(keyword));
+        dedentNext = (stringDelimiter === null) &&
+                     (dedentNextKeywords.some((keyword) => line.trim() == keyword)) ||
+                      dedentNextKeywords2.some((keyword) => line.trim().startsWith(keyword));
 
         // Keep track of the number of consecutive string delimiter's we've seen
         // in this line; this is used to tell if we are in a triple quoted string

--- a/src/indent.ts
+++ b/src/indent.ts
@@ -11,33 +11,33 @@ export function newlineAndIndent(
     // Get rid of any user selected text, since a selection is
     // always deleted whenever ENTER is pressed.
     // This should always happen first
-    let selected_text = textEditor.document.getText(textEditor.selection);
-    if (selected_text) {
+    let selectedText = textEditor.document.getText(textEditor.selection);
+    if (selectedText) {
         edit.delete(textEditor.selection);
         // Make sure we get rid of the selection range.
         // Find the earliest position of the selection
         // and set selection start and end to it.
-        let line_num = 0
-        let char_num = 0
-        const activeChar = textEditor.selection.active.character
-        const activeLine = textEditor.selection.active.line
-        const anchorChar = textEditor.selection.anchor.character
-        const anchorLine = textEditor.selection.anchor.line
+        let lineNum = 0;
+        let charNum = 0;
+        const activeChar = textEditor.selection.active.character;
+        const activeLine = textEditor.selection.active.line;
+        const anchorChar = textEditor.selection.anchor.character;
+        const anchorLine = textEditor.selection.anchor.line;
         if (activeLine < anchorLine) {
-            lineNum = activeLine
-            charNum = activeChar
+            lineNum = activeLine;
+            charNum = activeChar;
         } else if (activeLine > anchorLine) {
-            lineNum = anchorLine
-            charNum = anchorChar
+            lineNum = anchorLine;
+            charNum = anchorChar;
         } else { // Selection is on the same line so find the lowest character position
-            lineNum = activeLine
+            lineNum = activeLine;
             if (activeChar > anchorChar) {
-                charNum = anchorChar
+                charNum = anchorChar;
             } else {
-                charNum = activeChar
+                charNum = activeChar;
             }
         }
-        textEditor.selection = new vscode.Selection(line_num, char_num, line_num, char_num)
+        textEditor.selection = new vscode.Selection(lineNum, charNum, lineNum, charNum);
     }
 
     const position = textEditor.selection.active;

--- a/src/indent.ts
+++ b/src/indent.ts
@@ -19,14 +19,21 @@ export function newlineAndIndent(
     let hanging = Hanging.None;
     let toInsert = '\n';
 
-    // Get rid of any user selection since a selection is
+    // Get rid of any user selected text, since a selection is
     // always deleted whenever ENTER is pressed.
-    let selected = textEditor.document.getText(textEditor.selection);
-    if (selected) {
+    let selected_text = textEditor.document.getText(textEditor.selection);
+    if (selected_text) {
         edit.delete(textEditor.selection);
-        // Make sure we get rid of the selection range by moving the cursor.
-        // This is the equivalent of the user pushing the right arrow.
-        vscode.commands.executeCommand("cursorRight")
+        // TODO: A better way to clear the selection
+        // Make sure we get rid of the selection range.
+        // For lack of a more elegant solution we need to move the cursor
+        // whenever the user selected the text from left to right.
+        // For whatever reason, we don't need to do this if the user selects
+        // the text from right to left.
+        if (textEditor.selection.active.character > textEditor.selection.anchor.character) {
+            // This is the equivalent of the user pushing the right arrow.
+            vscode.commands.executeCommand("cursorRight");
+        }
     }
 
     try {

--- a/src/indent.ts
+++ b/src/indent.ts
@@ -11,8 +11,7 @@ export function newlineAndIndent(
     // Get rid of any user selected text, since a selection is
     // always deleted whenever ENTER is pressed.
     // This should always happen first
-    let selectedText = textEditor.document.getText(textEditor.selection);
-    if (selectedText) {
+    if (!textEditor.selection.isEmpty) {
         edit.delete(textEditor.selection);
         // Make sure we get rid of the selection range.
         textEditor.selection = new vscode.Selection(textEditor.selection.start, textEditor.selection.start);

--- a/src/indent.ts
+++ b/src/indent.ts
@@ -15,29 +15,7 @@ export function newlineAndIndent(
     if (selectedText) {
         edit.delete(textEditor.selection);
         // Make sure we get rid of the selection range.
-        // Find the earliest position of the selection
-        // and set selection start and end to it.
-        let lineNum = 0;
-        let charNum = 0;
-        const activeChar = textEditor.selection.active.character;
-        const activeLine = textEditor.selection.active.line;
-        const anchorChar = textEditor.selection.anchor.character;
-        const anchorLine = textEditor.selection.anchor.line;
-        if (activeLine < anchorLine) {
-            lineNum = activeLine;
-            charNum = activeChar;
-        } else if (activeLine > anchorLine) {
-            lineNum = anchorLine;
-            charNum = anchorChar;
-        } else { // Selection is on the same line so find the lowest character position
-            lineNum = activeLine;
-            if (activeChar > anchorChar) {
-                charNum = anchorChar;
-            } else {
-                charNum = activeChar;
-            }
-        }
-        textEditor.selection = new vscode.Selection(lineNum, charNum, lineNum, charNum);
+        textEditor.selection = new vscode.Selection(textEditor.selection.start, textEditor.selection.start);
     }
 
     const position = textEditor.selection.active;

--- a/src/indent.ts
+++ b/src/indent.ts
@@ -19,6 +19,16 @@ export function newlineAndIndent(
     let hanging = Hanging.None;
     let toInsert = '\n';
 
+    // Get rid of any user selection since a selection is
+    // always deleted whenever ENTER is pressed.
+    let selected = textEditor.document.getText(textEditor.selection);
+    if (selected) {
+        edit.delete(textEditor.selection);
+        // Make sure we get rid of the selection range by moving the cursor.
+        // This is the equivalent of the user pushing the right arrow.
+        vscode.commands.executeCommand("cursorRight")
+    }
+
     try {
         if (textEditor.document.languageId === 'python') {
             const lines = textEditor.document.getText(


### PR DESCRIPTION
Fixes #33 
I split the test for dedentNextKeywords into 2 tests, 1 for where the statement is on a line by itself and one for "return " and "raise " since they can have arguments that come after.