### PR TITLE
Fix try/else and for/else, simplify dedent logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### Unreleased
 
+### 1.8.0
+
+* Update dedent logic to handle `for...else` and `try...else` constructs.
+
 ### 1.7.0
 
 * Scroll the window when pressing `Enter` near the bottom of the window/out of view.

--- a/src/indent.ts
+++ b/src/indent.ts
@@ -75,21 +75,20 @@ export function extendCommentToNextLine(line: string, pos: number): boolean {
 
 // Returns the number of spaces that should be removed from the current line
 export function currentLineDedentation(lines: string[], tabSize: number): number {
-    const dedentKeywords: { [index: string]: string; } = {elif: "if", else: "if", except: "try", finally: "try"};
+    const dedentKeywords: { [index: string]: string[]; } =
+        {elif: ["if"], else: ["if", "try", "for"], except: ["try"], finally: ["try"]};
     // Reverse to help searching
     lines = lines.reverse();
     const line = lines[0];
     const trimmed = line.trim();
     if (trimmed.endsWith(":")) {
-        for (const keyword in dedentKeywords) {
-            if (trimmed.startsWith(keyword)) {
-                for (const matchedLine of lines.slice(1)) {
-                    const matchedLineTrimmed = matchedLine.trim();
-                    if (matchedLineTrimmed.endsWith(":") && matchedLineTrimmed.startsWith(dedentKeywords[keyword])) {
-                        const currentIndent = indentationLevel(line);
-                        const matchedIndent = indentationLevel(matchedLine);
-                        return Math.max(0, Math.min(tabSize, currentIndent, currentIndent - matchedIndent));
-                    }
+        for (const keyword of Object.keys(dedentKeywords).filter((key) => trimmed.startsWith(key))) {
+            for (const matchedLine of lines.slice(1).filter((l) => l.trim().endsWith(":"))) {
+                const matchedLineTrimmed = matchedLine.trim();
+                if (dedentKeywords[keyword].some((matcher) => matchedLineTrimmed.startsWith(matcher))) {
+                    const currentIndent = indentationLevel(line);
+                    const matchedIndent = indentationLevel(matchedLine);
+                    return Math.max(0, Math.min(tabSize, currentIndent, currentIndent - matchedIndent));
                 }
             }
         }

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -66,6 +66,53 @@ suite("dedent current line", function () {
                 "    finally:"
             ], 2));
     });
+    test("try...else", function () {
+        assert.equal(2, indent.currentLineDedentation(
+            [
+                "  try:",
+                "    pass",
+                "  except ValueError:",
+                "    pass",
+                "    else:"
+            ], 2));
+    });
+    test("if...try...else do not go past try", function () {
+        assert.equal(0, indent.currentLineDedentation(
+            [
+                "if True:",
+                "  try:",
+                "    pass",
+                "  except ValueError:",
+                "    pass",
+                "  else:"
+            ], 2));
+    });
+    test("for...else", function () {
+        assert.equal(2, indent.currentLineDedentation(
+            [
+                "  for i in range(5):",
+                "    pass",
+                "    else:"
+            ], 2));
+    });
+    test("if...for...else", function () {
+        assert.equal(2, indent.currentLineDedentation(
+            [
+                "if True:",
+                "  for i in range(5):",
+                "    pass",
+                "    else:"
+            ], 2));
+    });
+    test("if...for...else do not go past for", function () {
+        assert.equal(0, indent.currentLineDedentation(
+            [
+                "if True:",
+                "  for i in range(5):",
+                "    pass",
+                "  else:"
+            ], 2));
+    });
     test("do not dedent past matching if", function () {
         assert.equal(0, indent.currentLineDedentation(
             [


### PR DESCRIPTION
<!-- Please leave this checklist in your PR -->

**Checklist**
* [x] Relevant issues have been referenced
* [x] [CHANGELOG.md](../CHANGELOG.md) has been updated (bullet points added to the *Unreleased* section)
* [x] Tests have been added, or are not relevant

**Description**

Closes #53

List `try` and `for` as possible matches for `else` when dedenting. This correctly handles the following kind of cases:

```python
if True:
  try:
    pass
  except Exception:
    pass
    else:|
```
