### PR TITLE
Make full hanging indents optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### Unreleased
 
+### 1.11.0
+
+* Add option to control whether hanging indents put the bracket on its own line or not.
+
 ### 1.10.1
 
 * Update README to showcase new setting `trimLinesWithOnlyWhitespace`.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ Correct python indentation in Visual Studio Code. See the extension on the [VSCo
 
 ## How it works
 
-Every time you press the `Enter` key in a python context, this extension will parse your python file up to the location of your cursor, and determine exactly how much the next line (or two in the case of hanging indents) should be indented and how much nearby lines should be un-indented. There are three main cases.
+Every time you press the `Enter` key in a python context, this extension will parse your python file up to the location of your cursor, and determine exactly how much the next line (or two in the case of hanging indents) should be indented and how much nearby lines should be un-indented.
+
+There are three main cases when determining the correct indentation, described below.
 
 ### Between bracket pairs
 
@@ -68,7 +70,9 @@ result = my_func(
 ) # <- the closing bracket should end up here
 ```
 
-If there is other content, then this extension falls back on just indenting by your set tab size.
+You can use the setting `useTabOnHangingIndent` to make it so that when you are done typing you can simply press `Tab` to be taken to the closing bracket.
+
+If there is content to the right of your cursor when you press `Enter`, then this extension falls back on just indenting by your set tab size.
 
 ```python
 # The "|" is your cursor's location.
@@ -78,7 +82,9 @@ result = my_func(
     |x, y, z)
 ```
 
-It's not often used, but a backslash to continue a line will result in the next line being indented.
+If you never want to have the closing bracket end up on its own line (i.e. you always want to just indent by the set tab size), use the `keepHangingBracketOnLine` configuration setting. *Warning:* This may cause confusing indentation with function definitions as the argument list and the function code may end up at the same indentation level.
+
+It's not often used, but a backslash to continue a line will also result in the next line being indented.
 
 ```python
 my_long_calculation = 1234 + \
@@ -186,7 +192,7 @@ There are many related issues on GitHub ([[1]](https://github.com/Microsoft/vsco
 
 Known caveats are listed below.
 
-* Using tabs (`\t`) for your indentation will likely not work.
+* Using tabs (`\t`) for your indentation will not work.
 * If your python code is not correctly formatted, you may not get correct indentation.
 * The extension works by registering the `Enter` key as a keyboard shortcut. The conditions when the shortcut is triggered have been heavily restricted, but there may still be times this extension is unexpectedly overriding `Enter` behavior.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -66,9 +66,9 @@
 			"dev": true
 		},
 		"@types/vscode": {
-			"version": "1.45.0",
-			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.45.0.tgz",
-			"integrity": "sha512-b0Gyir7sPBCqiKLygAhn/AYVfzWD+SMPkWltBrIuPEyTOxSU1wVApWY/FcxYO2EWTRacoubTl4+gvZf86RkecA==",
+			"version": "1.48.0",
+			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.48.0.tgz",
+			"integrity": "sha512-sZJKzsJz1gSoFXcOJWw3fnKl2sseUgZmvB4AJZS+Fea+bC/jfGPVhmFL/FfQHld/TKtukVONsmoD3Pkyx9iadg==",
 			"dev": true
 		},
 		"agent-base": {
@@ -604,9 +604,9 @@
 			}
 		},
 		"lodash": {
-			"version": "4.17.15",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-			"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+			"version": "4.17.20",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+			"integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
 			"dev": true
 		},
 		"log-symbols": {

--- a/package.json
+++ b/package.json
@@ -12,9 +12,19 @@
 	},
 	"publisher": "KevinRose",
 	"license": "MIT",
-	"categories": ["Formatters", "Keymaps", "Programming Languages"],
-    "keywords": ["python", "indent", "dedent", "indentation", "whitespace"],
-    "qna": false,
+	"categories": [
+		"Formatters",
+		"Keymaps",
+		"Programming Languages"
+	],
+	"keywords": [
+		"python",
+		"indent",
+		"dedent",
+		"indentation",
+		"whitespace"
+	],
+	"qna": false,
 	"icon": "static/logo.png",
 	"activationEvents": [
 		"onLanguage:python",
@@ -76,7 +86,7 @@
 		"@types/glob": "^7.1.1",
 		"@types/mocha": "^7.0.2",
 		"@types/node": "^8.10.60",
-		"@types/vscode": "^1.45",
+		"@types/vscode": "^1.48",
 		"glob": "^7.1.1",
 		"mocha": "^7.1.2",
 		"tslint": "^6.1.2",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,11 @@
 					"type": "boolean",
 					"default": false,
 					"description": "Trims lines that contain only whitespace after pressing Enter on them."
+				},
+				"pythonIndent.keepHangingBracketOnLine": {
+					"type": "boolean",
+					"default": false,
+					"description": "When creating a hanging indent, do not put the closing bracket on its own line."
 				}
 			}
 		}

--- a/src/indent.ts
+++ b/src/indent.ts
@@ -43,6 +43,11 @@ export function newlineAndIndent(
                 indent = Math.max(indent - dedentAmount, 0);
             }
             hanging = shouldHang(currentLine, position.character);
+            if (settings.keepHangingBracketOnLine && hanging === Hanging.Full) {
+                // The only difference between partial and full is that
+                // full puts the closing bracket on its own line.
+                hanging = Hanging.Partial;
+            }
             if (hanging === Hanging.Partial) {
                 toInsert = '\n' + ' '.repeat(indentationLevel(currentLine) + tabSize);
             } else {


### PR DESCRIPTION
<!-- Please leave this checklist in your PR -->

**Checklist**
* [x] Relevant issues have been referenced
* [x] [CHANGELOG.md](../CHANGELOG.md) has been updated (bullet points added to the *Unreleased* section)
* [x] Tests have been added, or are not relevant

**Description**

Adds an option (`keepHangingBracketOnLine`) to always leave the closing bracket on the line with the rest of the code during a hanging indent.

Fixes #66 