### PR TITLE
Trim whitespace to right of cursor in some cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Unreleased
 
 * Updated required vscode version to 1.50 (September 2020 release)
+* Whitespace to the right of the cursor will now be deleted when pressing `Enter`. This only happens when there are non-whitespace characters to the left and to the right of the cursor, e.g. as in the case `def f(x,| y)` (where `|` is the cursor) but not in the case `    |print(x)` or `print(x)|  `. See [the issue](https://github.com/kbrose/vsc-python-indent/issues/62) for more information.
 
 ### 1.11.0
 

--- a/src/indent.ts
+++ b/src/indent.ts
@@ -35,7 +35,14 @@ export function newlineAndIndent(
 
             let { nextIndentationLevel: indent } = indentationInfo(lines, tabSize);
 
-            // const numCharsToDelete = whitespaceLength(currentLine.slice(position.character))
+            // If cursor is has whitespace to the right, followed by non-whitespace,
+            // and also has non-whitespace to the left, then trim the whitespace to the right
+            // of the cursor. E.g. in cases like "def f(x,| y):"
+            const numCharsToDelete = startingWhitespaceLength(currentLine.slice(position.character));
+            if ((numCharsToDelete > 0) && (/\S/.test(currentLine.slice(0, position.character)))) {
+                edit.delete(new vscode.Range(
+                    position, new vscode.Position(position.line, position.character + numCharsToDelete)));
+            }
 
             const dedentAmount = currentLineDedentation(lines, tabSize);
             const shouldTrim = trimCurrentLine(lines[lines.length-1], settings);
@@ -119,6 +126,6 @@ export function trimCurrentLine(line: string, settings: vscode.WorkspaceConfigur
 
 // Returns the number of whitespace characters until the next non-whitespace char
 // If there are no non-whitespace chars, returns 0, regardless of number of whitespace chars.
-export function whitespaceLength(line: string): number {
+export function startingWhitespaceLength(line: string): number {
     return /\S/.exec(line)?.index ?? 0;
 }

--- a/src/indent.ts
+++ b/src/indent.ts
@@ -35,6 +35,8 @@ export function newlineAndIndent(
 
             let { nextIndentationLevel: indent } = indentationInfo(lines, tabSize);
 
+            // const numCharsToDelete = whitespaceLength(currentLine.slice(position.character))
+
             const dedentAmount = currentLineDedentation(lines, tabSize);
             const shouldTrim = trimCurrentLine(lines[lines.length-1], settings);
             if ((dedentAmount > 0) || shouldTrim) {
@@ -113,4 +115,10 @@ export function trimCurrentLine(line: string, settings: vscode.WorkspaceConfigur
         }
     }
     return false;
+}
+
+// Returns the number of whitespace characters until the next non-whitespace char
+// If there are no non-whitespace chars, returns 0, regardless of number of whitespace chars.
+export function whitespaceLength(line: string): number {
+    return /\S/.exec(line)?.index ?? 0;
 }

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -254,3 +254,30 @@ suite("trim whitespace-only lines", function () {
         assert.equal(true, indent.trimCurrentLine("    \t", trueSetting));
     });
 });
+
+suite("detect whitespace length", function () {
+    test("empty string", function () {
+        assert.equal(0, indent.whitespaceLength(""));
+    });
+    test("space-only string", function () {
+        assert.equal(0, indent.whitespaceLength("   "));
+    });
+    test("tab-only-2 string", function () {
+        assert.equal(0, indent.whitespaceLength("\t\t"));
+    });
+    test("arbitrary whitespace-only string", function () {
+        assert.equal(0, indent.whitespaceLength("  \t\t "));
+    });
+    test("real example 1", function () {
+        assert.equal(4, indent.whitespaceLength("    4"));
+    });
+    test("real example 2", function () {
+        assert.equal(4, indent.whitespaceLength("    456"));
+    });
+    test("real example 3", function () {
+        assert.equal(5, indent.whitespaceLength("    \t56"));
+    });
+    test("real example 4", function () {
+        assert.equal(1, indent.whitespaceLength(" Quota Era Demonstratum"));
+    });
+});

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -257,27 +257,27 @@ suite("trim whitespace-only lines", function () {
 
 suite("detect whitespace length", function () {
     test("empty string", function () {
-        assert.equal(0, indent.whitespaceLength(""));
+        assert.equal(0, indent.startingWhitespaceLength(""));
     });
     test("space-only string", function () {
-        assert.equal(0, indent.whitespaceLength("   "));
+        assert.equal(0, indent.startingWhitespaceLength("   "));
     });
     test("tab-only-2 string", function () {
-        assert.equal(0, indent.whitespaceLength("\t\t"));
+        assert.equal(0, indent.startingWhitespaceLength("\t\t"));
     });
     test("arbitrary whitespace-only string", function () {
-        assert.equal(0, indent.whitespaceLength("  \t\t "));
+        assert.equal(0, indent.startingWhitespaceLength("  \t\t "));
     });
     test("real example 1", function () {
-        assert.equal(4, indent.whitespaceLength("    4"));
+        assert.equal(4, indent.startingWhitespaceLength("    4"));
     });
     test("real example 2", function () {
-        assert.equal(4, indent.whitespaceLength("    456"));
+        assert.equal(4, indent.startingWhitespaceLength("    456"));
     });
     test("real example 3", function () {
-        assert.equal(5, indent.whitespaceLength("    \t56"));
+        assert.equal(5, indent.startingWhitespaceLength("    \t56"));
     });
     test("real example 4", function () {
-        assert.equal(1, indent.whitespaceLength(" Quota Era Demonstratum"));
+        assert.equal(1, indent.startingWhitespaceLength(" Quota Era Demonstratum"));
     });
 });


### PR DESCRIPTION
<!-- Please leave this checklist in your PR -->

**Checklist**
* [x] Relevant issues have been referenced
* [x] [CHANGELOG.md](../CHANGELOG.md) has been updated (bullet points added to the *Unreleased* section)
* [x] Tests have been added, or are not relevant

**Description**

Whitespace to the right of the cursor will now be deleted when pressing `Enter`. This only happens if there is non-whitespace located somewhere both to the left and to the right of the cursor.

Examples, as usual, `|` represents the cursor.

```python
def f(x,| y):        # The extra space IS deleted
  | print(x)         # The space to the right IS NOT deleted - no non-whitespace to the left
    print(y)|<space> # The space to the right IS NOT deleted - no non-whitespace to the right
```

In this way, both of the following situations end up with the right indentation:

```python
def my_func(arg1,| arg2):


def my_func(arg1, |arg2):

# Both end up here:

def my_func(arg1,
            arg2):

# There may be an extra space after arg1 in the second case. If this is a problem
# for you, then use the files.trimTrailingWhitespace setting in VSCode.
```

Closes #62
