### PR TITLE
Correctly delete selected text starting w/ space

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Unreleased
 
+* Correctly delete selected text starting with space (fixes [#96](https://github.com/kbrose/vsc-python-indent/issues/96))
+
 ### 1.15.0
 
 * Update CI system to use Node v16

--- a/src/indent.ts
+++ b/src/indent.ts
@@ -13,7 +13,7 @@ export function newlineAndIndent(
     if (!textEditor.selection.isEmpty) {
         edit.delete(textEditor.selection);
         // Make sure we get rid of the selection range.
-        textEditor.selection = new vscode.Selection(textEditor.selection.start, textEditor.selection.start);
+        textEditor.selection = new vscode.Selection(textEditor.selection.end, textEditor.selection.end);
     }
 
     const position = textEditor.selection.active;


### PR DESCRIPTION
Fixes #96

If text was selected that also triggered the check for the following:

```js
    // If cursor has whitespace to the right, followed by non-whitespace,
    // and also has non-whitespace to the left, then trim the whitespace to the right
    // of the cursor. E.g. in cases like "def f(x,| y):"
```

then an invalid edit would be constructed and thus rejected, so no edits would be made.