### PR TITLE
In remote development, prefer to run on host

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Unreleased
 
+* When using remote development, prefer to run extension on the host (instead of locally) to reduce lag.
+
 ### 1.17.0
 
 * Fix dedent logic when the dedent keyword is preceded by a multi-line indent keyword

--- a/package.json
+++ b/package.json
@@ -79,6 +79,10 @@
 			}
 		}
 	},
+    "extensionKind": [
+        "ui",
+        "workspace"
+    ],
 	"scripts": {
 		"vscode:prepublish": "npm run compile",
 		"compile": "tsc -p ./",


### PR DESCRIPTION
**Checklist**
* [x] Relevant issues have been referenced
* [x] [CHANGELOG.md](../CHANGELOG.md) has been updated (bullet points added to the *Unreleased* section)
* [x] Tests have been added, or are not relevant

**Description**

Updates the default [extension kind](https://code.visualstudio.com/api/advanced-topics/extension-host#preferred-extension-location) to prefer UI with workspace fallback.

Based on feedback in https://github.com/kbrose/vsc-python-indent/issues/91 (and my personal usage for the past few months) it seems like this is a safe choice.