### PR TITLE
Fix tests by adding a type for Blob

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"description": "Correct Python indentation",
 	"version": "1.18.0",
 	"engines": {
-		"vscode": "^1.65.0"
+		"vscode": "^1.71.0"
 	},
 	"repository": {
 		"type": "git",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
 		"lib": [
 			"es6"
 		],
+        "typeRoots": ["./node_modules/@types", "./types"],
 		"sourceMap": true,
 		"rootDir": "src",
 		/* Strict Type-Checking Option */

--- a/types/Blob/index.d.ts
+++ b/types/Blob/index.d.ts
@@ -1,0 +1,2 @@
+// https://github.com/Stuk/jszip/issues/693
+type Blob = never;


### PR DESCRIPTION
<!-- Please leave this checklist in your PR -->

**Checklist**
* [x] Relevant issues have been referenced
* [x] [CHANGELOG.md](../CHANGELOG.md) has been updated (bullet points added to the *Unreleased* section)
* [x] Tests have been added, or are not relevant

**Description**

CICD started failing, presumably with the latest typescript release which added a reference to a type `Blob`, but without having said type. This MR adds the type directly to this repo, per the fix described in https://github.com/Stuk/jszip/issues/693#issuecomment-679283421