### PR TITLE
Fix duplicate setting entry in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ For more detailed explanation of the behavior, see the section "Detailed Behavio
 There are three exposed settings.
 
 * `pythonIndent.useTabOnHangingIndent`
-* `pythonIndent.useTabOnHangingIndent`
     * boolean, the default is false
     * If true, after creating a hanging indent (see [footnote 1 of PEP8](https://peps.python.org/pep-0008/#fn-hi) for a definition of a hanging indent), you can use the tab key to leave the indented section and go to the ending bracket.
 * `pythonIndent.trimLinesWithOnlyWhitespace`


### PR DESCRIPTION
Removed duplicate entry for 'pythonIndent.useTabOnHangingIndent' in README.

**Checklist**
* [ ] Relevant issues have been referenced
* [ ] [CHANGELOG.md](../CHANGELOG.md) has been updated (bullet points added to the *Unreleased* section)
* [x] Tests have been added, or are not relevant